### PR TITLE
Version 10.2

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@
 language: generic
 
 os: osx
+osx_image: beta-xcode6.1
 
 env:
   matrix:
@@ -11,6 +12,7 @@ env:
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "SJpIZ0BphLqAr/CfY1aLmh+YExE1S1Fxij9V4XWuWdzhDyTuHOFqdK+HJxtoJhX3ihLPBqc1ovnGa4HEN9EUxFxwe8CYYQE6ZxUhiIZv2ikMShcxhk8QaYz14f+v/pz9dHeNKI+vVij5HcoXuPzhpOAlNg4Qtgpl/fLwPV9WARsIDTyTh61vUHjm1GdBTeXXNVDTXXoN4rbd248U0dtI8F9mzUDLUVv6WnfDO6DAYfH2gxrf4IJmTOiwi/JmiKrky/FNwl7qHz4B86H4m9+cQabUINWg9463BqlRlVGV0v33nJVKzNgSQ7EkTJnuNCcPkXHU3CHsf/GXrUCgio+jw/GDXUwMS1sUBg5j8aehR7Gz+Slg6bZUCv4OJHj4k6R16Mi+k3F/SBMZEz/zNIl3NI9bEyhlEw80aB1nbdj2luE6FZWu43X3FCf4CjBHjFAg+P3vfQLCzKPBuGdgYqrzbRFSTWcw2TLM/U9xxchJRFvyJGWaV1IJfLX+2t/HztZqylzr8yCDwLf/Ty6Z6iUjGtaZhvEBbGtEZJC7evPMMSItIRkxw9vEFx2yfEhUJ2gT0suKn3H8n4EhzUn2hy0eNkYRVENSTp4JvjHMuM2fGuhpSoE6lJPwfSBvgxvdIlC+Z+kI2ZA/KpONxFWqkNcSf94s+kBhx+2V1fKOZdMqUIs="
@@ -24,9 +26,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -11,6 +11,18 @@ Summary: Store and access your passwords safely.
 
 
 
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/keyring-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/keyring-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/keyring-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/keyring-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/keyring-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/keyring-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/keyring/badges/version.svg)](https://anaconda.org/conda-forge/keyring)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/keyring/badges/downloads.svg)](https://anaconda.org/conda-forge/keyring)
+
 Installing keyring
 ==================
 
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `keyring` available on your platfo
 ```
 conda search keyring --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/keyring-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/keyring-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/keyring-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/keyring-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/keyring-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/keyring-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/keyring/badges/version.svg)](https://anaconda.org/conda-forge/keyring)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/keyring/badges/downloads.svg)](https://anaconda.org/conda-forge/keyring)
 
 
 Updating keyring-feedstock

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,35 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,14 +65,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
+
+    # Add a hack to switch to `conda` version `4.1.12` before activating.
+    # This is required to handle a long path activation issue.
+    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
+    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: set "OLDPATH="
+
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,22 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 3 case(s).
-    set -x
-    export CONDA_PY=27
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PY=34
-    set +x
-    conda build /recipe_root --quiet || exit 1
-    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
-
-    set -x
-    export CONDA_PY=35
-    set +x
+# Embarking on 1 case(s).
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
 EOF

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "9.0" %}
+{% set version = "10.2" %}
 
 package:
     name: keyring
@@ -7,7 +7,7 @@ package:
 source:
     fn: keyring-{{ version }}.tar.gz
     url: https://files.pythonhosted.org/packages/source/k/keyring/keyring-{{ version }}.tar.gz
-    sha256: 1c1222298da2100128f821c57096c69cb6cec0d22ba3b66c2859ae95ae473799
+    sha256: bf49be09b31db401791bde1799da30d6926e7de2f0fb836c3dfc85aa5538a572
     patches:
         - verbose-tests.patch
         - use-pywin32.patch
@@ -17,6 +17,7 @@ build:
     script: python setup.py install --single-version-externally-managed --record=record.txt
     entry_points:
         - keyring=keyring.cli:main
+    skip: True  # [linux]
 
 requirements:
     build:
@@ -45,7 +46,7 @@ test:
 
 about:
     home: https://github.com/jaraco/keyring
-    license: Python Software Foundation License or MIT License
+    license: Python Software Foundation or MIT
     summary: 'Store and access your passwords safely.'
 
 extra:

--- a/recipe/use-pywin32.patch
+++ b/recipe/use-pywin32.patch
@@ -1,13 +1,13 @@
 diff --git a/setup.py b/setup.py
-index 2afa185..0d777f9 100644
---- setup.py
-+++ setup.py
-@@ -37,7 +37,7 @@ setup_params = dict(
+index 05f9ed6..aa1b5bb 100644
+--- a/setup.py
++++ b/setup.py
+@@ -32,7 +32,7 @@ setup_params = dict(
+     install_requires=[
      ],
      extras_require={
-         'test': test_requirements,
 -        ':sys_platform=="win32"': ['pywin32-ctypes'],
 +        ':sys_platform=="win32"': ['pywin32'],
-     },
-     setup_requires=[
-         'setuptools_scm>=1.9',
+         ':sys_platform=="linux2" or sys_platform=="linux"': [
+             "secretstorage",
+         ],


### PR DESCRIPTION
Update to the latest version and rerender the recipe with latest conda smithy.

Linux build is skipped as secretstorage requirement is not available on conda-forge, and one of its requirements, and those requirements also have requirements ...