### PR TITLE
update linux requirements

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
         - python
         - pywin32-ctypes  # [win]
         - entrypoints
+        - secretstorage   # [linux]
 
 test:
     imports:
@@ -35,6 +36,7 @@ test:
         - keyring.tests.backends
         - keyring.util
     commands:
+        - python -c "import pkg_resources; pkg_resources.require('keyring')"
         - keyring --help
 
 about:


### PR DESCRIPTION
keyring depends on secretstorage package on linux:
https://github.com/jaraco/keyring/blob/master/setup.py#L62