### PR TITLE
ENH add v21 to abi migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,3 +321,6 @@ Feedstock Maintainers
 * [@licode](https://github.com/licode/)
 * [@tacaswell](https://github.com/tacaswell/)
 
+
+<!-- dummy commit to enable rerendering -->
+

--- a/README.md
+++ b/README.md
@@ -321,6 +321,3 @@ Feedstock Maintainers
 * [@licode](https://github.com/licode/)
 * [@tacaswell](https://github.com/tacaswell/)
 
-
-<!-- dummy commit to enable rerendering -->
-

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,3 +1,6 @@
+bot:
+  abi_migration_branches:
+    - v21.2.1
 build_platform:
   linux_aarch64: linux_64
   linux_ppc64le: linux_64


### PR DESCRIPTION
The bot is missing key migrations because the older version pinned by downstream deps like poetry is not getting migrated. 

Fixes #70